### PR TITLE
Fix form alignment across pages

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -63,20 +63,20 @@
 
     <h2>Напишите нам</h2>
     <form id="contact-form" class="contacts">
-      <label>Имя
+      <label><span>Имя</span>
         <input type="text" name="name" required>
       </label>
-      <label>Email
+      <label><span>Email</span>
         <input type="email" name="email" required>
       </label>
-      <label>Тема
+      <label><span>Тема</span>
         <input type="text" name="topic" required>
       </label>
-      <label>Сообщение
+      <label><span>Сообщение</span>
         <textarea name="msg" required></textarea>
       </label>
       <!-- произвольное поле -->
-      <label>Прикрепить ссылку на ТЗ
+      <label><span>Прикрепить ссылку на ТЗ</span>
         <input type="url" name="doc">
       </label>
       <input type="submit" value="Отправить">

--- a/css/style.css
+++ b/css/style.css
@@ -235,8 +235,35 @@ hr {
 }
 .product-detail ul { list-style: square inside; margin-bottom: 12px; }
 
+.contacts {
+  max-width: 540px;
+}
+
+.contacts label {
+  display: flex;
+  align-items: center;
+  margin: 10px 0;
+}
+
+.contacts label span {
+  width: 220px;
+  text-align: right;
+  margin-right: 10px;
+  flex-shrink: 0;
+}
+
+.contacts .rating-options {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 300px;
+}
+
 .contacts input[type="text"],
 .contacts input[type="email"],
+.contacts input[type="password"],
+.contacts input[type="url"],
+.contacts select,
 .contacts textarea {
   width: 300px;
   height: 30px;

--- a/guestbook.php
+++ b/guestbook.php
@@ -63,13 +63,13 @@ $entries = file_exists($file) ? file($file, FILE_IGNORE_NEW_LINES) : [];
     <h2>Гостевая книга</h2>
     <?php if($posted): ?><p>Спасибо за отзыв!</p><?php endif; ?>
     <form method="post" action="guestbook.php" class="contacts">
-      <label>Имя
+      <label><span>Имя</span>
         <input type="text" name="name" required>
       </label>
-      <label>Город
+      <label><span>Город</span>
         <input type="text" name="city">
       </label>
-      <label>Любимый продукт
+      <label><span>Любимый продукт</span>
         <select name="product">
           <option value="CRM‑PRO">CRM‑PRO</option>
           <option value="Mobile‑Suite">Mobile‑Suite</option>
@@ -77,15 +77,19 @@ $entries = file_exists($file) ? file($file, FILE_IGNORE_NEW_LINES) : [];
           <option value="Portal‑X">Portal‑X</option>
         </select>
       </label>
-      <label>Оценка
-        <input type="radio" name="rating" value="1">1
-        <input type="radio" name="rating" value="2">2
-        <input type="radio" name="rating" value="3" checked>3
-        <input type="radio" name="rating" value="4">4
-        <input type="radio" name="rating" value="5">5
+      <label><span>Оценка</span>
+        <span class="rating-options">
+          <input type="radio" name="rating" value="1">1
+          <input type="radio" name="rating" value="2">2
+          <input type="radio" name="rating" value="3" checked>3
+          <input type="radio" name="rating" value="4">4
+          <input type="radio" name="rating" value="5">5
+        </span>
       </label>
-      <label><input type="checkbox" name="subscribe" value="1"> Подписаться на новости</label>
-      <label>Комментарий
+      <label><span>Подписаться на новости</span>
+        <input type="checkbox" name="subscribe" value="1">
+      </label>
+      <label><span>Комментарий</span>
         <textarea name="comment" rows="4" cols="40"></textarea>
       </label>
       <button type="submit">Отправить</button>

--- a/register.html
+++ b/register.html
@@ -44,16 +44,16 @@
   <article>
     <h2>Регистрация</h2>
     <form class="contacts">
-      <label>Имя
+      <label><span>Имя</span>
         <input type="text" required>
       </label>
-      <label>Email
+      <label><span>Email</span>
         <input type="email" required>
       </label>
-      <label>Пароль
+      <label><span>Пароль</span>
         <input type="password" required>
       </label>
-      <label>Повторите пароль
+      <label><span>Повторите пароль</span>
         <input type="password" required>
       </label>
       <input type="submit" value="Зарегистрироваться">


### PR DESCRIPTION
## Summary
- align fields for contacts, guestbook and registration pages
- style contacts forms to share the same label width

## Testing
- `php -l guestbook.php` *(fails: command not found)*
- `tidy -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684162874630832180d7f1c578e88022