### PR TITLE
Improve registration flow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -369,6 +369,16 @@ input[type="submit"]:hover {
   cursor: pointer;
 }
 
+#user-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.user-icon {
+  font-size: 1.2em;
+}
+
 #site-search {
   display: flex;
   gap: 6px;

--- a/js/main.js
+++ b/js/main.js
@@ -11,8 +11,22 @@ document.addEventListener('DOMContentLoaded', () => {
             info = document.createElement('div');
             info.id = 'user-info';
             loginForm.after(info);
+        } else {
+            info.innerHTML = '';
         }
-        info.textContent = `Вы вошли как ${user}`;
+        const icon = document.createElement('span');
+        icon.className = 'user-icon';
+        icon.textContent = '\u{1F464}';
+        const logout = document.createElement('button');
+        logout.id = 'logout-btn';
+        logout.textContent = 'выход';
+        logout.addEventListener('click', () => {
+            localStorage.removeItem('user');
+            info.remove();
+            loginForm.style.display = '';
+        });
+        info.appendChild(icon);
+        info.appendChild(logout);
     }
 
     if (loginForm) {

--- a/register.php
+++ b/register.php
@@ -41,38 +41,98 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <meta charset="UTF-8">
   <title>Регистрация</title>
   <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/main.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-<h2>Регистрация</h2>
-<?php if($success): ?>
-<p>Регистрация прошла успешно.</p>
-<script>
-localStorage.setItem('user', <?=json_encode($name)?>);
-setTimeout(function(){ location.href='index.html'; }, 2000);
-</script>
-<?php else: ?>
-<?php if($errors): ?>
-<ul>
-<?php foreach($errors as $e): ?>
-  <li><?=htmlspecialchars($e)?></li>
-<?php endforeach; ?>
-</ul>
-<?php endif; ?>
-<form method="post" class="contacts" action="register.php">
-  <label>Имя
-    <input type="text" name="name" value="<?=htmlspecialchars($name ?? '')?>" required>
-  </label>
-  <label>Email
-    <input type="email" name="email" value="<?=htmlspecialchars($email ?? '')?>" required>
-  </label>
-  <label>Пароль
-    <input type="password" name="pass" required>
-  </label>
-  <label>Повторите пароль
-    <input type="password" name="pass2" required>
-  </label>
-  <input type="submit" value="Зарегистрироваться">
-</form>
-<?php endif; ?>
+<header>
+  <div class="logo"><img src="images/logo.jpg" alt="Логотип"></div>
+  <div class="site-title">ГАЛАКТИКА</div>
+  <form id="login-form">
+    <input type="text" name="login" placeholder="логин" required>
+    <input type="password" name="pass" placeholder="пароль" required>
+    <input type="submit" value="Войти">
+  </form>
+</header>
+<nav class="top">
+  <ul class="nav-links">
+    <li><a href="index.html">Главная</a></li>
+    <li><a href="about.html">О нас</a></li>
+    <li><a href="catalog.html">Каталог</a></li>
+    <li><a href="contacts.html">Контакты</a></li>
+    <li><a href="guestbook.php">Отзывы</a></li>
+    <li><a href="register.php">Регистрация</a></li>
+  </ul>
+  <form id="site-search" method="get" action="search.php">
+    <input type="text" name="q" placeholder="поиск">
+    <input type="submit" value="искать">
+  </form>
+</nav>
+<main>
+  <aside class="sidebar-left">
+    <ul>
+      <li><a href="index.html">Страница 1</a></li>
+      <li><a href="about.html">Страница 2</a></li>
+      <li><a href="catalog.html">Страница 3</a></li>
+      <li><a href="contacts.html">Страница 4</a></li>
+    </ul>
+  </aside>
+
+  <article>
+    <h2>Регистрация</h2>
+    <?php if($success): ?>
+      <p class="notice">Регистрация прошла успешно.</p>
+      <script>
+        localStorage.setItem('user', <?=json_encode($name)?>);
+        setTimeout(function(){ location.href='index.html'; }, 2000);
+      </script>
+    <?php else: ?>
+      <?php if($errors): ?>
+      <ul>
+      <?php foreach($errors as $e): ?>
+        <li><?=htmlspecialchars($e)?></li>
+      <?php endforeach; ?>
+      </ul>
+      <?php endif; ?>
+      <form method="post" class="contacts" action="register.php">
+        <label><span>Имя</span>
+          <input type="text" name="name" value="<?=htmlspecialchars($name ?? '')?>" required>
+        </label>
+        <label><span>Email</span>
+          <input type="email" name="email" value="<?=htmlspecialchars($email ?? '')?>" required>
+        </label>
+        <label><span>Пароль</span>
+          <input type="password" name="pass" required>
+        </label>
+        <label><span>Повторите пароль</span>
+          <input type="password" name="pass2" required>
+        </label>
+        <input type="submit" value="Зарегистрироваться">
+      </form>
+    <?php endif; ?>
+  </article>
+
+  <aside class="sidebar-right">
+    <div class="banner">
+      <a href="https://www.salesforce.com/crm/what-is-crm/" target="_blank">
+        <img src="https://www.techmatrixconsulting.com/images/services/crm-banner-mob.jpg" alt="Salesforce CRM">
+      </a>
+    </div>
+    <div class="banner">
+      <a href="https://developer.android.com/" target="_blank">
+        <img src="https://i.pinimg.com/236x/58/52/82/585282f0fa2543021550dd06f145a073.jpg" alt="Android Mobile Development">
+      </a>
+    </div>
+    <div class="banner">
+      <a href="https://aws.amazon.com/products/compute/" target="_blank">
+        <img src="https://avatars.mds.yandex.net/i?id=87ab1b5f1ad3f72f5e0d0c4d5ccce48ff0c3a698-4955727-images-thumbs&n=13" alt="AWS Cloud Compute">
+      </a>
+    </div>
+    <p class="banner-note">(кликните на баннер для перехода к товару)</p>
+  </aside>
+</main>
+<footer id="footer">
+  &copy; 2025 ООО «Галактика». Все права защищены
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend `register.php` layout to match other pages
- display a success notification and hide the login form
- auto-redirect to the authorised view after two seconds
- show a user icon with a logout button when logged in

## Testing
- `php -l register.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684170bea2f08321a312b5825ce94cad