### PR TITLE
Implement feedback persistence

### DIFF
--- a/contact_submit.php
+++ b/contact_submit.php
@@ -1,0 +1,37 @@
+<?php
+require_once __DIR__.'/db.php';
+header('Content-Type: application/json; charset=utf-8');
+
+$name = trim($_POST['name'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$topic = trim($_POST['topic'] ?? '');
+$msg = trim($_POST['msg'] ?? '');
+$doc = trim($_POST['doc'] ?? '');
+
+$errors = [];
+if ($name === '' || $email === '' || $topic === '' || $msg === '') {
+    $errors[] = 'Заполните все обязательные поля.';
+}
+if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $errors[] = 'Некорректный email.';
+}
+if ($errors) {
+    http_response_code(400);
+    echo json_encode(['error' => implode(' ', $errors)], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+$mysqli = get_db_connection();
+$stmt = $mysqli->prepare('INSERT INTO feedback (created_at,name,email,topic,message,doc_url) VALUES (NOW(),?,?,?,?,?)');
+if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(['error' => 'DB error'], JSON_UNESCAPED_UNICODE);
+    $mysqli->close();
+    exit;
+}
+$stmt->bind_param('sssss', $name, $email, $topic, $msg, $doc);
+$stmt->execute();
+$stmt->close();
+$mysqli->close();
+
+echo json_encode(['ok' => true]);

--- a/contacts.html
+++ b/contacts.html
@@ -62,7 +62,7 @@
   </iframe>
 
     <h2>Напишите нам</h2>
-    <form id="contact-form" class="contacts">
+    <form id="contact-form" class="contacts" method="post" action="contact_submit.php">
       <label><span>Имя</span>
         <input type="text" name="name" required>
       </label>

--- a/db/init.sql
+++ b/db/init.sql
@@ -57,6 +57,17 @@ CREATE TABLE IF NOT EXISTS users (
   password_hash VARCHAR(255) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- Feedback messages from contact form
+CREATE TABLE IF NOT EXISTS feedback (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  created_at DATETIME NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  topic VARCHAR(255) NOT NULL,
+  message TEXT NOT NULL,
+  doc_url VARCHAR(255) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- Insert sample products
 INSERT INTO product (manufacturer_id,name,alias,short_description,description,price,image,available,meta_keywords,meta_description,meta_title)
 VALUES

--- a/js/main.js
+++ b/js/main.js
@@ -58,6 +58,21 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    const contactForm = document.getElementById('contact-form');
+    if (contactForm) {
+        contactForm.addEventListener('submit', async e => {
+            e.preventDefault();
+            const fd = new FormData(contactForm);
+            const res = await fetch(contactForm.action, { method: 'POST', body: fd });
+            if (res.ok) {
+                contactForm.innerHTML = '<p>Спасибо, ваше сообщение отправлено.</p>';
+            } else {
+                const data = await res.json().catch(() => null);
+                alert(data && data.error ? data.error : 'Ошибка отправки');
+            }
+        });
+    }
   
     // ======= подсветка активного пункта верхнего меню =======
     const current = location.pathname.split('/').pop();


### PR DESCRIPTION
## Summary
- create a DB table `feedback`
- add server endpoint to store contact form messages
- send contact form via AJAX and show success message

## Testing
- `php -l contact_submit.php`
- `php -l register.php`
- `php -l login.php`
- `php -l guestbook.php`
- `php -l search.php`


------
https://chatgpt.com/codex/tasks/task_e_68418ecbe3808321b6d6c566afdbb459